### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 </div>
 
+<a href="https://glama.ai/mcp/servers/@hyperb1iss/droidmind">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hyperb1iss/droidmind/badge" alt="DroidMind MCP server" />
+</a>
+
 DroidMind is a powerful bridge between AI assistants and Android devices, enabling control, debugging, and system analysis through natural language. By implementing the Model Context Protocol (MCP), DroidMind allows AI models to directly interact with Android devices via ADB in a secure, structured way. When used as part of an agentic coding workflow, DroidMind can enable your assistant to build and debug with your device directly in the loop.
 
 ## 💫 Features


### PR DESCRIPTION
This PR adds a badge for the [DroidMind](https://glama.ai/mcp/servers/@hyperb1iss/droidmind) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hyperb1iss/droidmind">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hyperb1iss/droidmind/badge" alt="DroidMind MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.